### PR TITLE
Allow versions to float at the minor level.

### DIFF
--- a/ruby-stackoverflow.gemspec
+++ b/ruby-stackoverflow.gemspec
@@ -18,12 +18,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "httparty", "~> 0.11.0"
+  spec.add_runtime_dependency "httparty", "~> 0.11"
   spec.add_runtime_dependency  "json"
 
   spec.add_development_dependency "rspec", "~> 2.1"
-  spec.add_development_dependency "webmock", "~> 1.14.0"
-  spec.add_development_dependency "vcr","~> 2.7.0"
+  spec.add_development_dependency "webmock", "~> 1.14"
+  spec.add_development_dependency "vcr","~> 2.7"
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake", "~> 10.1.0"
+  spec.add_development_dependency "rake", "~> 10.1"
 end


### PR DESCRIPTION
When I depend on ruby-stackoverflow it restricts the version space of some of my dependencies to the 'minor' version and I miss out on backwards-compatible improvements in those dependencies. This pull is to allow dependencies of ruby-stackoverflow to float at the minor level instead of the patch level. 

http://semver.org/