### PR TITLE
make site configurable, default 'stackoverflow'

### DIFF
--- a/lib/ruby-stackoverflow/client.rb
+++ b/lib/ruby-stackoverflow/client.rb
@@ -53,12 +53,13 @@ module RubyStackoverflow
     def append_params_to_url(url, options)
       url = Configuration.api_url + url
       options.merge!(key_params)
+      options[:site] ||= configuration.site || 'stackoverflow'
       options = options.to_a.map{|k,v|"#{k}=#{v}"}
       url+'?'+options.join('&')
     end
 
     def key_params
-      {key: configuration.client_key, site: 'stackoverflow', access_token: configuration.access_token}
+      {key: configuration.client_key, access_token: configuration.access_token}
     end
 
     def configuration

--- a/lib/ruby-stackoverflow/configuration.rb
+++ b/lib/ruby-stackoverflow/configuration.rb
@@ -1,6 +1,7 @@
 module RubyStackoverflow
   class Configuration
     attr_accessor(
+      :site,
       :client_id,
       :client_secret,
       :client_key,


### PR DESCRIPTION
Make it possible to change Stack Exchange site (stackoverflow, serverfault, etc) in configuration and on each request.